### PR TITLE
Colorize list output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "cosmic-randr",
  "fomat-macros",
  "futures-lite",
+ "nu-ansi-term 0.49.0",
  "tachyonix",
  "tokio",
  "wayland-client",
@@ -463,6 +464,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -763,7 +773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
  "sharded-slab",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,3 +17,4 @@ cosmic-randr = { path = "../lib" }
 tachyonix = "0.2.1"
 tokio = { version = "1.35.0", features = [ "macros", "rt" ]}
 wayland-client = "0.31.1"
+nu-ansi-term = "0.49.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,6 +3,7 @@
 
 use clap::Parser;
 use cosmic_randr::{AdaptiveSyncState, Context};
+use nu_ansi_term::{Color, Style};
 use std::{fmt::Write as FmtWrite, io::Write};
 use wayland_client::Proxy;
 
@@ -125,27 +126,30 @@ fn list(context: &Context) {
         #[allow(clippy::ignored_unit_patterns)]
         let _res = fomat_macros::witeln!(
             &mut output,
-            (head.name) "\n"
-            "  Enabled: " (head.enabled) "\n"
-            "  Make: "
-            if head.make.is_empty() {
-                "Unknown"
+            (Style::new().bold().paint(&head.name)) " "
+            if head.enabled {
+                (Color::Green.bold().paint("(enabled)"))
             } else {
-                (head.make)
+                (Color::Red.bold().paint("(disabled)"))
             }
-            "\n"
-            "  Model: " (head.model) "\n"
-            "  PhysicalSize: " (head.physical_width) "x" (head.physical_height) " mm\n"
-            "  Position: " (head.position_x) "," (head.position_y) "\n"
+            if !head.make.is_empty() {
+                (Color::Yellow.bold().paint("\n  Make: ")) (head.make)
+            }
+            (Color::Yellow.bold().paint("\n  Model: "))
+            (head.model)
+            (Color::Yellow.bold().paint("\n  Physical Size: "))
+            (head.physical_width) " x " (head.physical_height) " mm"
+            (Color::Yellow.bold().paint("\n  Position: "))
+            (head.position_x) "," (head.position_y)
             if let Some(sync) = head.adaptive_sync {
-                "    Adaptive Sync: "
+                (Color::Yellow.bold().paint("\n  Adaptive Sync: "))
                 if let AdaptiveSyncState::Enabled = sync {
-                    "true\n"
+                    (Color::Green.paint("true\n"))
                 } else {
-                    "false\n"
+                    (Color::Red.paint("false\n"))
                 }
             }
-            "  Modes:"
+            (Color::Yellow.bold().paint("\n  Modes:"))
         );
 
         for mode_id in &head.modes {
@@ -158,15 +162,22 @@ fn list(context: &Context) {
 
             let _res = writeln!(
                 &mut output,
-                "    {:>9} @ {:>3}.{:02} Hz{}{}",
-                &resolution,
-                mode.refresh / 1000,
-                mode.refresh % 1000,
-                if mode.preferred { " (preferred)" } else { "" },
-                if head.current_mode.as_ref() == Some(mode_id) {
-                    " (current)"
+                "    {:>9} @ {}{}{}",
+                Color::Magenta.paint(format!("{resolution:>9}")),
+                Color::Cyan.paint(format!(
+                    "{:>3}.{:02} Hz",
+                    mode.refresh / 1000,
+                    mode.refresh % 1000
+                )),
+                if mode.preferred {
+                    Color::Green.bold().paint(" (preferred)")
                 } else {
-                    ""
+                    Color::default().paint("")
+                },
+                if head.current_mode.as_ref() == Some(mode_id) {
+                    Color::Purple.bold().paint(" (current)")
+                } else {
+                    Color::default().paint("")
                 }
             );
         }


### PR DESCRIPTION
Uses the `nu_ansi_term` crate to colorize the default list. Does not affect the KDL list output because the KDL output mode is meant to be used by programs parsing the output.

![cosmic-randr](https://github.com/pop-os/cosmic-randr/assets/4143535/09ccbd58-84fe-47ab-8cff-cd59e2c2033f)

Outputs are displayed via cosmic-term.