### PR TITLE
randr: Add mirroring support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ version = "0.1.0"
 dependencies = [
  "cosmic-protocols",
  "futures-lite",
+ "indexmap",
  "tachyonix",
  "thiserror",
  "tokio",
@@ -268,6 +269,12 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -336,10 +343,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "io-lifetimes"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,9 +184,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "cosmic-protocols"
+version = "0.1.0"
+source = "git+https://github.com/pop-os/cosmic-protocols.git#1316f9e1148ec65351471d8a046ffc82171b066e"
+dependencies = [
+ "bitflags 2.4.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "wayland-server",
+]
+
+[[package]]
 name = "cosmic-randr"
 version = "0.1.0"
 dependencies = [
+ "cosmic-protocols",
  "futures-lite",
  "tachyonix",
  "thiserror",
@@ -255,6 +270,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "io-lifetimes"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a611371471e98973dbcab4e0ec66c31a10bc356eeb4d54a0e05eac8158fe38c"
+
+[[package]]
 name = "kdl"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +379,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "log"
@@ -597,6 +634,19 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.38.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rustversion"
@@ -880,6 +930,7 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
+ "wayland-server",
 ]
 
 [[package]]
@@ -893,6 +944,7 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "wayland-scanner",
+ "wayland-server",
 ]
 
 [[package]]
@@ -904,6 +956,20 @@ dependencies = [
  "proc-macro2",
  "quick-xml",
  "quote",
+]
+
+[[package]]
+name = "wayland-server"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00e6e4d5c285bc24ba4ed2d5a4bd4febd5fd904451f465973225c8e99772fdb7"
+dependencies = [
+ "bitflags 2.4.1",
+ "downcast-rs",
+ "io-lifetimes",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
 ]
 
 [[package]]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -224,6 +224,10 @@ impl App {
 
     async fn list(&mut self, kdl: bool) -> Result<(), Box<dyn std::error::Error>> {
         let _res = self.context.dispatch(&mut self.event_queue).await;
+        for head in self.context.output_heads.values_mut() {
+            head.modes
+                .sort_unstable_by(|_, either, _, or| either.cmp(or));
+        }
 
         if kdl {
             list_kdl(&self.context);

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,3 +14,4 @@ tracing = "0.1.40"
 wayland-client = "0.31.1"
 wayland-protocols-wlr = { version = "0.2.0", features = [ "client", "wayland-client" ] }
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols.git" }
+indexmap = "2.2.6"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,3 +13,4 @@ tokio = { version = "1.35.1", features = ["net"] }
 tracing = "0.1.40"
 wayland-client = "0.31.1"
 wayland-protocols-wlr = { version = "0.2.0", features = [ "client", "wayland-client" ] }
+cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols.git" }

--- a/lib/src/context.rs
+++ b/lib/src/context.rs
@@ -2,36 +2,273 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::output_head::OutputHead;
-use crate::output_mode::OutputMode;
 use crate::{Error, Message};
+use cosmic_protocols::output_management::v1::client::zcosmic_output_configuration_head_v1::ZcosmicOutputConfigurationHeadV1;
+use cosmic_protocols::output_management::v1::client::zcosmic_output_configuration_v1::ZcosmicOutputConfigurationV1;
+use cosmic_protocols::output_management::v1::client::zcosmic_output_manager_v1::ZcosmicOutputManagerV1;
 use std::collections::HashMap;
+use std::fmt;
 use tachyonix::Sender;
-use wayland_client::protocol::wl_registry::WlRegistry;
+use wayland_client::protocol::{wl_output::Transform, wl_registry::WlRegistry};
 use wayland_client::{backend::ObjectId, Connection, Proxy, QueueHandle};
 use wayland_client::{DispatchError, EventQueue};
+use wayland_protocols_wlr::output_management::v1::client::zwlr_output_configuration_head_v1::ZwlrOutputConfigurationHeadV1;
 use wayland_protocols_wlr::output_management::v1::client::zwlr_output_configuration_v1::ZwlrOutputConfigurationV1;
 use wayland_protocols_wlr::output_management::v1::client::zwlr_output_head_v1::ZwlrOutputHeadV1;
 use wayland_protocols_wlr::output_management::v1::client::zwlr_output_manager_v1::ZwlrOutputManagerV1;
-use wayland_protocols_wlr::output_management::v1::client::zwlr_output_mode_v1::ZwlrOutputModeV1;
 
 #[derive(Debug)]
 pub struct Context {
-    pub data: Data,
     pub connection: Connection,
     pub handle: QueueHandle<Context>,
     sender: Sender<Message>,
-    pub output_configuration: Option<ZwlrOutputConfigurationV1>,
+
     pub output_manager: Option<ZwlrOutputManagerV1>,
+    pub cosmic_output_manager: Option<ZcosmicOutputManagerV1>,
     pub output_manager_serial: u32,
     pub output_manager_version: u32,
+
     pub output_heads: HashMap<ObjectId, OutputHead>,
-    pub output_modes: HashMap<ObjectId, OutputMode>,
-    pub mode_to_head_ids: HashMap<ObjectId, ObjectId>,
     pub wl_registry: WlRegistry,
 }
 
-#[derive(Copy, Clone, Default, Debug)]
-pub struct Data;
+#[derive(Debug)]
+pub struct Configuration {
+    obj: ZwlrOutputConfigurationV1,
+    cosmic_obj: Option<ZcosmicOutputConfigurationV1>,
+    cosmic_output_manager: Option<ZcosmicOutputManagerV1>,
+    handle: QueueHandle<Context>,
+
+    known_heads: Vec<OutputHead>,
+    configured_heads: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct HeadConfiguration {
+    /// Specifies the width and height of the output picture.
+    pub size: Option<(u32, u32)>,
+    /// Specifies the refresh rate to apply to the output.
+    pub refresh: Option<f32>,
+    /// Position the output within this x pixel coordinate.
+    pub pos: Option<(i32, i32)>,
+    /// Changes the dimensions of the output picture.
+    pub scale: Option<f64>,
+    /// Specifies a transformation matrix to apply to the output.
+    pub transform: Option<Transform>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ConfigurationError {
+    OutputAlreadyConfigured,
+    UnknownOutput,
+    ModeNotFound,
+    NoCosmicExtension,
+    PositionForMirroredOutput,
+    MirroringItself,
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OutputAlreadyConfigured => f.write_str("Output configured twice"),
+            Self::UnknownOutput => f.write_str("Unknown output"),
+            Self::ModeNotFound => f.write_str("Unknown or unsupported mode"),
+            Self::NoCosmicExtension => f.write_str("Mirroring isn't available outside COSMIC"),
+            Self::PositionForMirroredOutput => f.write_str("You cannot position a mirrored output"),
+            Self::MirroringItself => f.write_str("Output mirroring itself"),
+        }
+    }
+}
+impl std::error::Error for ConfigurationError {}
+
+impl Configuration {
+    pub fn disable_head(&mut self, output: &str) -> Result<(), ConfigurationError> {
+        if self.configured_heads.iter().any(|o| o == output) {
+            return Err(ConfigurationError::OutputAlreadyConfigured);
+        }
+        self.configured_heads.push(output.to_string());
+
+        let head = self
+            .known_heads
+            .iter()
+            .find(|head| head.name == output)
+            .ok_or(ConfigurationError::UnknownOutput)?;
+        self.obj.disable_head(&head.wlr_head);
+
+        Ok(())
+    }
+
+    pub fn enable_head(
+        &mut self,
+        output: &str,
+        mode: Option<HeadConfiguration>,
+    ) -> Result<(), ConfigurationError> {
+        if self.configured_heads.iter().any(|o| o == output) {
+            return Err(ConfigurationError::OutputAlreadyConfigured);
+        }
+        self.configured_heads.push(output.to_string());
+
+        let head = self
+            .known_heads
+            .iter()
+            .find(|head| head.name == output)
+            .ok_or(ConfigurationError::UnknownOutput)?;
+        let head_config = self.obj.enable_head(&head.wlr_head, &self.handle, ());
+        let cosmic_head_config = self
+            .cosmic_output_manager
+            .as_ref()
+            .map(|extension| extension.get_configuration_head(&head_config, &self.handle, ()));
+
+        if let Some(args) = mode {
+            send_mode_to_config_head(head, head_config, cosmic_head_config, args)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn mirror_head(
+        &mut self,
+        output: &str,
+        mirrored: &str,
+        mode: Option<HeadConfiguration>,
+    ) -> Result<(), ConfigurationError> {
+        if self.cosmic_obj.is_none() {
+            return Err(ConfigurationError::NoCosmicExtension);
+        }
+
+        if self.configured_heads.iter().any(|o| o == output) {
+            return Err(ConfigurationError::OutputAlreadyConfigured);
+        }
+
+        if output == mirrored {
+            return Err(ConfigurationError::MirroringItself);
+        }
+
+        if mode.as_ref().is_some_and(|mode| mode.pos.is_some()) {
+            return Err(ConfigurationError::PositionForMirroredOutput);
+        }
+
+        self.configured_heads.push(output.to_string());
+
+        let head = self
+            .known_heads
+            .iter()
+            .find(|head| head.name == output)
+            .ok_or(ConfigurationError::UnknownOutput)?;
+        let mirror_head = self
+            .known_heads
+            .iter()
+            .find(|head| head.name == mirrored)
+            .ok_or(ConfigurationError::UnknownOutput)?;
+
+        let cosmic_obj = self.cosmic_obj.as_ref().unwrap();
+        let head_config =
+            cosmic_obj.mirror_head(&head.wlr_head, &mirror_head.wlr_head, &self.handle, ());
+        let cosmic_head_config = self
+            .cosmic_output_manager
+            .as_ref()
+            .map(|extension| extension.get_configuration_head(&head_config, &self.handle, ()));
+
+        if let Some(args) = mode {
+            send_mode_to_config_head(head, head_config, cosmic_head_config, args)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn test(mut self) {
+        let known_heads = self.known_heads.clone();
+        let configured_heads = self.configured_heads.clone();
+        for output in known_heads
+            .iter()
+            .filter(|output| !configured_heads.iter().any(|name| *name == output.name))
+        {
+            if output.enabled {
+                self.enable_head(&output.name, None).unwrap();
+            } else {
+                self.disable_head(&output.name).unwrap();
+            }
+        }
+        self.obj.test();
+    }
+
+    pub fn apply(mut self) {
+        let known_heads = self.known_heads.clone();
+        let configured_heads = self.configured_heads.clone();
+        for output in known_heads
+            .iter()
+            .filter(|output| !configured_heads.iter().any(|name| *name == output.name))
+        {
+            if output.enabled {
+                self.enable_head(&output.name, None).unwrap();
+            } else {
+                self.disable_head(&output.name).unwrap();
+            }
+        }
+        self.obj.apply();
+    }
+
+    pub fn cancel(self) {
+        self.obj.destroy()
+    }
+}
+
+fn send_mode_to_config_head(
+    head: &OutputHead,
+    head_config: ZwlrOutputConfigurationHeadV1,
+    cosmic_head_config: Option<ZcosmicOutputConfigurationHeadV1>,
+    args: HeadConfiguration,
+) -> Result<(), ConfigurationError> {
+    if let Some(scale) = args.scale {
+        if let Some(cosmic_obj) = cosmic_head_config {
+            cosmic_obj.set_scale_1000((scale * 1000.0) as i32);
+        } else {
+            head_config.set_scale(scale);
+        }
+    }
+
+    if let Some(transform) = args.transform {
+        head_config.set_transform(transform);
+    }
+
+    if let Some((x, y)) = args.pos {
+        head_config.set_position(x, y);
+    }
+
+    let mode_iter = || {
+        head.modes.values().filter(|mode| {
+            if let Some((width, height)) = args.size {
+                mode.width == width as i32 && mode.height == height as i32
+            } else {
+                head.current_mode
+                    .as_ref()
+                    .is_some_and(|current_mode| mode.wlr_mode.id() == *current_mode)
+            }
+        })
+    };
+
+    if let Some(refresh) = args.refresh {
+        #[allow(clippy::cast_possible_truncation)]
+        let refresh = (refresh * 1000.0) as i32;
+
+        let min = refresh - 501;
+        let max = refresh + 501;
+
+        if let Some(mode) = mode_iter().find(|mode| min < mode.refresh && max > mode.refresh) {
+            head_config.set_mode(&mode.wlr_mode);
+            Ok(())
+        } else {
+            Err(ConfigurationError::ModeNotFound)
+        }
+    } else {
+        if let Some(mode) = mode_iter().next() {
+            head_config.set_mode(&mode.wlr_mode);
+            Ok(())
+        } else {
+            Err(ConfigurationError::ModeNotFound)
+        }
+    }
+}
 
 impl Context {
     pub fn callback(
@@ -51,70 +288,54 @@ impl Context {
         self.sender.send(event).await
     }
 
-    pub fn create_output_config(&mut self) -> ZwlrOutputConfigurationV1 {
-        self.destroy_output_config();
+    pub fn create_output_config(&mut self) -> Configuration {
         let configuration = self.output_manager.as_ref().unwrap().create_configuration(
             self.output_manager_serial,
             &self.handle,
-            self.data,
+            (),
         );
-        self.output_configuration = Some(configuration.clone());
-        configuration
-    }
 
-    pub fn destroy_output_config(&mut self) {
-        if let Some(config) = &self.output_configuration {
-            config.destroy();
-            self.output_configuration = None;
+        let cosmic_configuration = self
+            .cosmic_output_manager
+            .as_ref()
+            .map(|extension| extension.get_configuration(&configuration, &self.handle, ()));
+
+        Configuration {
+            obj: configuration,
+            cosmic_obj: cosmic_configuration,
+            cosmic_output_manager: self.cosmic_output_manager.clone(),
+            handle: self.handle.clone(),
+            known_heads: self.output_heads.values().cloned().collect(),
+            configured_heads: Vec::new(),
         }
-    }
-
-    pub(crate) fn remove_mode(&mut self, id: &ObjectId) -> Result<(), Error> {
-        let head_id = self
-            .mode_to_head_ids
-            .remove(&id)
-            .ok_or(Error::ReleaseOutputMode)?;
-
-        let head = self
-            .output_heads
-            .get_mut(&head_id)
-            .ok_or(Error::ReleaseOutputMode)?;
-
-        if let Some(mode_id) = &head.current_mode {
-            if mode_id == id {
-                head.current_mode = None;
-            }
-        }
-
-        head.modes.retain(|e| e != id);
-
-        Ok(())
     }
 
     pub fn connect(sender: Sender<Message>) -> Result<(Self, EventQueue<Self>), Error> {
         let connection = Connection::connect_to_env()?;
-        let data = Data::default();
 
-        let event_queue = connection.new_event_queue();
+        let mut event_queue = connection.new_event_queue();
         let handle = event_queue.handle();
 
         let display = connection.display();
-        let wl_registry = display.get_registry(&handle, data);
+        let wl_registry = display.get_registry(&handle, ());
 
-        let context = Self {
+        let mut context = Self {
             connection,
             handle,
-            data,
             output_manager_serial: Default::default(),
             output_manager: Default::default(),
+            cosmic_output_manager: Default::default(),
             output_manager_version: Default::default(),
-            output_configuration: Default::default(),
             output_heads: Default::default(),
-            output_modes: Default::default(),
-            mode_to_head_ids: Default::default(),
             sender,
             wl_registry,
         };
+
+        event_queue.roundtrip(&mut context)?;
+        // second roundtrip for extension protocol
+        if context.cosmic_output_manager.is_some() {
+            event_queue.roundtrip(&mut context)?;
+        }
 
         Ok((context, event_queue))
     }
@@ -129,15 +350,6 @@ impl Context {
     }
 
     pub fn clear(&mut self) {
-        self.destroy_output_config();
-
-        for (id, _) in std::mem::take(&mut self.output_modes) {
-            match ZwlrOutputModeV1::from_id(&self.connection, id) {
-                Ok(it) => it.release(),
-                Err(err) => tracing::debug!("{}", err),
-            }
-        }
-
         for (id, _) in std::mem::take(&mut self.output_heads) {
             match ZwlrOutputHeadV1::from_id(&self.connection, id) {
                 Ok(it) => it.release(),

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -3,7 +3,6 @@
 
 pub mod context;
 pub use context::Context;
-use context::Data;
 
 pub mod output_configuration;
 pub mod output_configuration_head;

--- a/lib/src/output_configuration.rs
+++ b/lib/src/output_configuration.rs
@@ -1,22 +1,21 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
-use super::{Context, Data, Message};
+use super::{Context, Message};
+use cosmic_protocols::output_management::v1::client::zcosmic_output_configuration_v1::ZcosmicOutputConfigurationV1;
 use wayland_client::{Connection, Dispatch, Proxy, QueueHandle};
 use wayland_protocols_wlr::output_management::v1::client::zwlr_output_configuration_v1::Event;
 use wayland_protocols_wlr::output_management::v1::client::zwlr_output_configuration_v1::ZwlrOutputConfigurationV1;
 
-impl Dispatch<ZwlrOutputConfigurationV1, Data> for Context {
+impl Dispatch<ZwlrOutputConfigurationV1, ()> for Context {
     fn event(
         state: &mut Self,
         _proxy: &ZwlrOutputConfigurationV1,
         event: <ZwlrOutputConfigurationV1 as Proxy>::Event,
-        _data: &Data,
+        _data: &(),
         _conn: &Connection,
         _handle: &QueueHandle<Self>,
     ) {
-        state.destroy_output_config();
-
         futures_lite::future::block_on(async {
             match event {
                 Event::Succeeded => {
@@ -31,5 +30,17 @@ impl Dispatch<ZwlrOutputConfigurationV1, Data> for Context {
                 _ => tracing::debug!(?event, "unknown event"),
             }
         });
+    }
+}
+
+impl Dispatch<ZcosmicOutputConfigurationV1, ()> for Context {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ZcosmicOutputConfigurationV1,
+        _event: <ZcosmicOutputConfigurationV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _handle: &QueueHandle<Self>,
+    ) {
     }
 }

--- a/lib/src/output_configuration_head.rs
+++ b/lib/src/output_configuration_head.rs
@@ -1,17 +1,30 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
-use crate::{Context, Data};
+use crate::Context;
 
+use cosmic_protocols::output_management::v1::client::zcosmic_output_configuration_head_v1::ZcosmicOutputConfigurationHeadV1;
 use wayland_client::{Connection, Dispatch, Proxy, QueueHandle};
 use wayland_protocols_wlr::output_management::v1::client::zwlr_output_configuration_head_v1::ZwlrOutputConfigurationHeadV1;
 
-impl Dispatch<ZwlrOutputConfigurationHeadV1, Data> for Context {
+impl Dispatch<ZwlrOutputConfigurationHeadV1, ()> for Context {
     fn event(
         _state: &mut Self,
         _proxy: &ZwlrOutputConfigurationHeadV1,
         _event: <ZwlrOutputConfigurationHeadV1 as Proxy>::Event,
-        _data: &Data,
+        _data: &(),
+        _conn: &Connection,
+        _handle: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<ZcosmicOutputConfigurationHeadV1, ()> for Context {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ZcosmicOutputConfigurationHeadV1,
+        _event: <ZcosmicOutputConfigurationHeadV1 as Proxy>::Event,
+        _data: &(),
         _conn: &Connection,
         _handle: &QueueHandle<Self>,
     ) {

--- a/lib/src/output_head.rs
+++ b/lib/src/output_head.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
-use std::collections::HashMap;
 use std::sync::Mutex;
 
 use crate::{Context, OutputMode};
 
 use cosmic_protocols::output_management::v1::client::zcosmic_output_head_v1::Event as ZcosmicOutputHeadEvent;
 use cosmic_protocols::output_management::v1::client::zcosmic_output_head_v1::ZcosmicOutputHeadV1;
+use indexmap::IndexMap;
 use wayland_client::backend::ObjectId;
 use wayland_client::event_created_child;
 use wayland_client::protocol::wl_output::Transform;
@@ -27,7 +27,7 @@ pub struct OutputHead {
     pub enabled: bool,
     pub make: String,
     pub model: String,
-    pub modes: HashMap<ObjectId, OutputMode>,
+    pub modes: IndexMap<ObjectId, OutputMode>,
     pub name: String,
     pub physical_height: i32,
     pub physical_width: i32,
@@ -164,7 +164,7 @@ impl OutputHead {
             enabled: false,
             make: String::new(),
             model: String::new(),
-            modes: HashMap::new(),
+            modes: IndexMap::new(),
             name: String::new(),
             physical_height: 0,
             physical_width: 0,

--- a/lib/src/output_mode.rs
+++ b/lib/src/output_mode.rs
@@ -1,6 +1,7 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
+use std::cmp::Ordering;
 use std::sync::Mutex;
 
 use crate::Context;
@@ -56,7 +57,7 @@ impl Dispatch<ZwlrOutputModeV1, Mutex<Option<ObjectId>>> for Context {
                     proxy.release();
                 }
 
-                head.modes.remove(&proxy.id());
+                head.modes.shift_remove(&proxy.id());
             }
 
             _ => tracing::debug!(?event, "unknown event"),
@@ -74,5 +75,21 @@ impl OutputMode {
             preferred: false,
             wlr_mode,
         }
+    }
+}
+
+impl PartialOrd for OutputMode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OutputMode {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.width
+            .cmp(&other.width)
+            .then(self.height.cmp(&other.height))
+            .then(self.refresh.cmp(&other.refresh))
+            .reverse()
     }
 }

--- a/shell/src/lib.rs
+++ b/shell/src/lib.rs
@@ -41,6 +41,7 @@ pub struct List {
 pub struct Output {
     pub name: String,
     pub enabled: bool,
+    pub mirroring: Option<String>,
     pub make: Option<String>,
     pub model: String,
     pub physical: (u32, u32),
@@ -57,6 +58,7 @@ impl Output {
         Self {
             name: String::new(),
             enabled: false,
+            mirroring: None,
             make: None,
             model: String::new(),
             physical: (0, 0),
@@ -280,6 +282,14 @@ pub async fn list() -> Result<List, Error> {
                             }
 
                             output.modes.push(mode_id);
+                        }
+                    }
+                }
+
+                "mirroring" => {
+                    if let Some(entry) = node.entries().first() {
+                        if let Some(string) = entry.value().as_string() {
+                            output.mirroring = Some(string.to_string());
                         }
                     }
                 }


### PR DESCRIPTION
This does a bunch of refactoring to cosmic-randr to add support for our upcoming `cosmic-output-management` protocol: https://github.com/pop-os/cosmic-protocols/pull/26.

Most notably, it cleans up a bit of the wayland-rs usage:
- Gets rid of useless `Data`-type
- Uses more userdata instead of `ObjectId`-hashmaps, where it makes sense (e.g. for Modes)

Additionally
- Store scale in a more precise f64 (e.g. 130% can't be cleanly represented without more precision)
- Bind cosmic-output-management when available and use it for more precise scale and mirroring.
- Actually always send `enable`/`disable`/`mirror` requests for all heads as required by the protocol
- Automatically perform the initial dispatches on connect to populate all data fields
- Don't bind whatever version of `wlr-output-management` the compositor advertises, but the highest known one (4 in our case).
- Only send release-events for supported versions

Missing features:
- [x] KDL output isn't touched, as I am not sure what cosmic-settings expects and didn't want to introduce accidental breakage
- [ ] No way to set adaptive-sync (although it is reported now). Currently this feature can still be quite buggy, so this is left to be enabled later, once necessary refactoring/bugfixing in cosmic-comp is done

Should be tested against https://github.com/pop-os/cosmic-comp/pull/448

