### PR TITLE
Fixes for behavior with disabled/mirrored outputs

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -332,6 +332,10 @@ impl App {
                     return None;
                 };
 
+                if !head.enabled || head.mirroring.is_some() {
+                    return None;
+                }
+
                 let (width, height) = if head.transform.map_or(true, |wl_transform| {
                     Transform::try_from(wl_transform).map_or(true, is_landscape)
                 }) {
@@ -357,6 +361,7 @@ impl App {
             self.context
                 .output_heads
                 .values()
+                .filter(|head| head.enabled && head.mirroring.is_none())
                 .fold((i32::MAX, i32::MAX), |offset, head| {
                     let (x, y) = if output == head.name {
                         (active_output.x as i32, active_output.y as i32)
@@ -372,6 +377,7 @@ impl App {
             .context
             .output_heads
             .values()
+            .filter(|head| head.enabled && head.mirroring.is_none())
             .map(|head| {
                 let (x, y) = if output == head.name {
                     (active_output.x as i32, active_output.y as i32)


### PR DESCRIPTION
Disabling or mirroring should also invoke `auto_correct_offsets` to make sure gaps aren't left between outputs, but that is non-trivial since it needs to work on the other outputs without a specific `active_output`. I've left that unchanged for now.

It would also be nice if `auto_correct_offsets` could work without an additional `.apply` call. Though output configuration application that doesn't change any DRM properties should be pretty instantaneous, so that isn't a major issue.

(The logic for avoiding gaps/overlap/etc. perhaps also should be shared by cosmic-comp, which needs to do something similar when a new output is detected, but I think has its own separate implementation currently.)