### PR TITLE
new Xwayland compatibility command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols.git#d218c76b58c7a3b20dd5e7943f93fc306a1b81b8"
+source = "git+https://github.com/pop-os/cosmic-protocols.git#67df697105486fa4c9dd6ce00889c8b0526c9bb4"
 dependencies = [
  "bitflags",
  "wayland-backend",
@@ -267,7 +267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -679,7 +679,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/lib/src/output_manager.rs
+++ b/lib/src/output_manager.rs
@@ -23,15 +23,21 @@ impl Dispatch<ZwlrOutputManagerV1, ()> for Context {
     ) {
         match event {
             ZwlrOutputManagerEvent::Head { head } => {
-                if let Some(cosmic_extension) = state.cosmic_output_manager.as_ref() {
-                    cosmic_extension.get_head(&head, handle, head.id());
+                let cosmic_head =
+                    if let Some(cosmic_extension) = state.cosmic_output_manager.as_ref() {
+                        let cosmic_head = cosmic_extension.get_head(&head, handle, head.id());
 
-                    // Use `sync` callback to wait until `get_head` is processed and
-                    // we also have cosmic extension events.
-                    let callback = conn.display().sync(handle, ());
-                    state.cosmic_manager_sync_callback = Some(callback);
-                }
-                state.output_heads.insert(head.id(), OutputHead::new(head));
+                        // Use `sync` callback to wait until `get_head` is processed and
+                        // we also have cosmic extension events.
+                        let callback = conn.display().sync(handle, ());
+                        state.cosmic_manager_sync_callback = Some(callback);
+                        Some(cosmic_head)
+                    } else {
+                        None
+                    };
+                state
+                    .output_heads
+                    .insert(head.id(), OutputHead::new(head, cosmic_head));
             }
 
             ZwlrOutputManagerEvent::Done { serial } => {

--- a/lib/src/wl_registry.rs
+++ b/lib/src/wl_registry.rs
@@ -45,7 +45,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for Context {
             if "zcosmic_output_manager_v1" == &interface[..] {
                 state.cosmic_output_manager = Some(registry.bind::<ZcosmicOutputManagerV1, _, _>(
                     name,
-                    version.min(2),
+                    version.min(3),
                     handle,
                     (),
                 ))

--- a/shell/src/lib.rs
+++ b/shell/src/lib.rs
@@ -52,6 +52,7 @@ pub struct Output {
     pub current: Option<ModeKey>,
     pub adaptive_sync: Option<AdaptiveSyncState>,
     pub adaptive_sync_availability: Option<AdaptiveSyncAvailability>,
+    pub xwayland_primary: Option<bool>,
 }
 
 impl Output {
@@ -71,6 +72,7 @@ impl Output {
             current: None,
             adaptive_sync: None,
             adaptive_sync_availability: None,
+            xwayland_primary: None,
         }
     }
 }
@@ -370,6 +372,14 @@ pub async fn list() -> Result<List, Error> {
                     if let Some(entry) = node.entries().first() {
                         if let Some(string) = entry.value().as_string() {
                             output.mirroring = Some(string.to_string());
+                        }
+                    }
+                }
+
+                "xwayland_primary" => {
+                    if let Some(entry) = node.entries().first() {
+                        if let Some(val) = entry.value().as_bool() {
+                            output.xwayland_primary = Some(val);
                         }
                     }
                 }


### PR DESCRIPTION
This adds a new `xwayland` command, which can currently be used to set the primary-output as understood by Xwayland.

~~Blocked on https://github.com/pop-os/cosmic-protocols/pull/57 currently, but can be merged before https://github.com/pop-os/cosmic-comp/pull/1337 and will error out correctly.~~