### PR TITLE
fix(cli): output VRR state in a format that cosmic-randr-shell parses correctly

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -753,18 +753,18 @@ fn list_kdl(context: &Context) {
             if let Some(available) = head.adaptive_sync_support {
                 "  adaptive_sync_support \""
                 (match available {
-                    AdaptiveSyncAvailability::Supported => "true",
+                    AdaptiveSyncAvailability::Supported => "kdl_true",
                     AdaptiveSyncAvailability::RequiresModeset => "requires_modeset",
-                    _ => "false",
+                    _ => "kdl_false",
                 })
                 "\"\n"
             }
             if let Some(sync) = head.adaptive_sync {
                 "  adaptive_sync \""
                 (match sync {
-                    AdaptiveSyncStateExt::Always => "true",
+                    AdaptiveSyncStateExt::Always => "kdl_true",
                     AdaptiveSyncStateExt::Automatic => "automatic",
-                    _ => "false",
+                    _ => "kdl_false",
                 })
                 "\"\n"
             }


### PR DESCRIPTION
Following https://github.com/pop-os/cosmic-randr/commit/2c1cef722900dd8177a627377e89194560c5bd51, `cosmic-randr-shell` expects a different format for the VRR values (with a `kdl_` prefix for booleans). I am not sure why that is needed over plain `true`/`false` values, but if that's the case the CLI output also needs to reflect it.

This change fixes the VRR options not showing up in cosmic-settings on my system, as they were not parsed correctly previously.