### PR TITLE
Fix: Display Output config being applied to wrong output

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -518,18 +518,19 @@ impl App {
         let mut current_heads: Vec<_> = self.context.output_heads.values_mut().collect();
 
         for (_, head) in list.outputs.drain() {
-            let desired_serial = head.serial_number.trim();
-            let desired_make = head.make.clone().unwrap_or_default();
-            let desired_model = head.model.clone();
-
+            let head_serial = head.serial_number.trim();
+            let head_make = head.make.clone().unwrap_or_default();
+            let head_model = head.model.clone();
             let mut matched_index = None;
-            if !desired_serial.is_empty() {
+
+            // First try to match by serial number
+            if !head_serial.is_empty() {
                 for (i, current) in current_heads.iter().enumerate() {
                     let current_serial = current.serial_number.trim();
                     if !current_serial.is_empty()
-                        && current_serial == desired_serial
-                        && current.make == desired_make
-                        && current.model == desired_model
+                        && current_serial == head_serial
+                        && current.make == head_make
+                        && current.model == head_model
                     {
                         matched_index = Some(i);
                         break;
@@ -537,11 +538,12 @@ impl App {
                 }
             }
 
+            // Next try to match by name, make, and model
             if matched_index.is_none() {
                 for (i, current) in current_heads.iter().enumerate() {
                     if current.name == head.name
-                        && current.make == head.make.clone().unwrap_or_default()
-                        && current.model == head.model
+                        && current.make == head_make
+                        && current.model == head_model
                     {
                         matched_index = Some(i);
                         break;

--- a/shell/src/lib.rs
+++ b/shell/src/lib.rs
@@ -599,11 +599,6 @@ impl From<List> for KdlDocument {
         for (_output_key, output) in value.outputs.iter() {
             let mut output_node = kdl::KdlNode::new("output");
 
-            // Serial number (if any)
-            if !output.serial_number.is_empty() {
-                output_node.push(output.serial_number.clone());
-            }
-
             // Display adapter name (unnamed)
             output_node.push(output.name.clone());
 
@@ -612,6 +607,14 @@ impl From<List> for KdlDocument {
 
             // Children: description, physical, position, scale, transform, adaptive_sync, adaptive_sync_support, mirroring, xwayland_primary, modes
             let mut children = KdlDocument::new();
+
+            // serial_number node
+            let serial_number = output.serial_number.trim();
+            if !serial_number.is_empty() {
+                let mut node = kdl::KdlNode::new("serial_number");
+                node.push(serial_number.to_string());
+                children.nodes_mut().push(node);
+            }
 
             // description node
             if output.make.is_some() || !output.model.is_empty() {
@@ -741,7 +744,7 @@ mod test {
         let mode2_key = list.modes.insert(mode2);
 
         let output = Output {
-            serial_number: String::new(),
+            serial_number: "ABC123".to_string(),
             name: "HDMI-A-1".to_string(),
             enabled: true,
             mirroring: Some("eDP-1".to_string()),


### PR DESCRIPTION
## Problem
Displays of the same make & model can confuse cosmic-randr & cosmic-comp, leading to the wrong configuration being applied. This presents as one display's rotation, scaling, position, etc. being applied to another. This occurs (at least in my experience) on ~50% of boots & re-connections of outputs.

## Cause
The order of Display adapters is not guaranteed upon boot/connection, and therefore the names that are derived from this order  (eg. `DP-1` or `HDMI-2`) are not actually tied to a physical port, and can switch. 

## Solution
When restoring configuration from KDL, try to match via `output.serial_number` first, and fallback to name matching if serials are not present. 

## Changes
 - Serial-first matching on KDL "set" command
 - Print serial in standard "list" command (if not empty/whitespace).


## Test Plan

- [x] Build Succeeds
- [x] `cosmic-randr list` prints serial under make & model (if present)
- [x] `cosmic-randr list --kdl` prints serial if present
- [x] `cosmic-randr kdl` accepts KDL containing serial
- [x] on `apply_list`, outputs are matched by serial first    

 This change is a dependency of https://github.com/pop-os/cosmic-comp/pull/2020
